### PR TITLE
feat: Make classix even faster/smaller

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ function cx(): string {
   while (i < arguments.length) {
     if (
       (arg = arguments[i++]) &&
-      arg &&
       (typeof arg === "string" || typeof arg === "number")
     ) {
       str && (str += " ");

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,13 @@ function cx(): string {
     arg: unknown;
 
   while (i < arguments.length) {
-    if ((arg = arguments[i++]) && arg && (typeof arg === "string" || typeof arg === "number")) {
-        str && (str += " ");
-        str += arg;
+    if (
+      (arg = arguments[i++]) &&
+      arg &&
+      (typeof arg === "string" || typeof arg === "number")
+    ) {
+      str && (str += " ");
+      str += arg;
     }
   }
   return str;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,17 +9,12 @@ function cx(...args: Argument[]): string;
 function cx(): string {
   let str = "",
     i = 0,
-    arg: unknown,
-    val: string | number;
+    arg: unknown;
 
   while (i < arguments.length) {
-    if ((arg = arguments[i++])) {
-      if (
-        (val = typeof arg === "string" || typeof arg === "number" ? arg : "")
-      ) {
+    if ((arg = arguments[i++]) && arg && (typeof arg === "string" || typeof arg === "number")) {
         str && (str += " ");
-        str += val;
-      }
+        str += arg;
     }
   }
   return str;


### PR DESCRIPTION
For some reason, the current version is actually slower than clsx on my M1 Pro. These changes should save a few bytes and improve performance by a decent margin!

|M1 Pro|
|-|
|classnames x 11,202,602 ops/sec ±0.15% (96 runs sampled)|
|clsx x 29,227,810 ops/sec ±0.17% (98 runs sampled)|
|cx x 31,156,631 ops/sec ±0.14% (100 runs sampled)|