### PR TITLE
docs: Update classix's size in the comparison section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ cx(
 
 |              | classix                                          | clsx                                          | classnames                                          |
 | ------------ | ------------------------------------------------ | --------------------------------------------- | --------------------------------------------------- |
-| **Size**     | [281B](https://bundlephobia.com/package/classix) | [330B](https://bundlephobia.com/package/clsx) | [454B](https://bundlephobia.com/package/classnames) |
+| **Size**     | [277B](https://bundlephobia.com/package/classix) | [330B](https://bundlephobia.com/package/clsx) | [454B](https://bundlephobia.com/package/classnames) |
 | **Ops/s\***  | 29M                                              | 28M                                           | 7M                                                  |
 | **Strings**  | Yes                                              | Yes                                           | Yes                                                 |
 | **Numbers**  | Yes                                              | Yes                                           | Yes                                                 |


### PR DESCRIPTION
The comparison section mentioned `281B` for classix's size, which was true for v1.0.5, but since v1.1.0 (thanks to https://github.com/alexnault/classix/pull/8) the minified + gzipped size is actually `277B`.

<img width="600" alt="Screen Shot 2022-07-20 at 4 55 10 PM" src="https://user-images.githubusercontent.com/7189823/180080428-1dbb80f0-b8d5-42d0-802f-78bcadaf3f4f.png">

