### PR TITLE
feat(breaking-change): Reduce size by ignoring numbers as arguments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-type Argument = string | boolean | number | null | undefined;
+type Argument = string | boolean | null | undefined;
 
 /**
  * Conditionally join classNames into a single string
@@ -12,10 +12,7 @@ function cx(): string {
     arg: unknown;
 
   while (i < arguments.length) {
-    if (
-      (arg = arguments[i++]) &&
-      (typeof arg === "string" || typeof arg === "number")
-    ) {
+    if ((arg = arguments[i++]) && typeof arg === "string") {
       str && (str += " ");
       str += arg;
     }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -35,11 +35,28 @@ describe("cx", () => {
 
     expect(cx("foo", true ? "bar1" : "bar2")).toBe("foo bar1");
     expect(cx("foo", false ? "bar1" : "bar2")).toBe("foo bar2");
+
+    expect(cx("0")).toBe("0");
+    expect(cx("7")).toBe("7");
   });
 
   it("number", () => {
+    // @ts-expect-error Testing outside of types
     expect(cx(0)).toBe("");
-    expect(cx(7)).toBe("7");
+    // @ts-expect-error Testing outside of types
+    expect(cx(7)).toBe("");
+    // @ts-expect-error Testing outside of types
+    expect(cx(-7)).toBe("");
+    // @ts-expect-error Testing outside of types
+    expect(cx(-0)).toBe("");
+    // @ts-expect-error Testing outside of types
+    expect(cx(1_000_000)).toBe("");
+    // @ts-expect-error Testing outside of types
+    expect(cx(1.5)).toBe("");
+    // @ts-expect-error Testing outside of types
+    expect(cx(333e9)).toBe("");
+    // @ts-expect-error Testing outside of types
+    expect(cx(Infinity)).toBe("");
   });
 
   it("object", () => {


### PR DESCRIPTION
BREAKING CHANGE: Numbers are unsuited for classes and are therefore no longer supported as arguments.