### PR TITLE
chore: Place types first in exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/classix.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/classix.d.ts",
       "require": "./dist/cjs/classix.js",
-      "import": "./dist/esm/classix.mjs",
-      "types": "./dist/classix.d.ts"
+      "import": "./dist/esm/classix.mjs"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
As recommended by https://publint.dev/rules#exports_types_should_be_first