### PR TITLE
types: improve type inference for cx concatenation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,35 @@
 export type ClassName = string | boolean | null | undefined;
 
+type FilterStrings<T extends readonly unknown[]> = T extends readonly [
+  infer F,
+  ...infer R,
+]
+  ? F extends string
+    ? [F, ...FilterStrings<R>]
+    : FilterStrings<R>
+  : [];
+
+type JoinStrings<T extends readonly string[]> = T extends readonly [
+  infer F,
+  ...infer R,
+]
+  ? F extends string
+    ? R extends readonly string[]
+      ? R["length"] extends 0
+        ? F
+        : `${F} ${JoinStrings<R>}`
+      : F
+    : never
+  : "";
+
 /**
  * Conditionally join classNames into a single string
  * @param {...String} args The expressions to evaluate
  * @returns {String} The joined classNames
  */
-function cx(...args: ClassName[]): string;
+function cx<T extends readonly ClassName[]>(
+  ...args: T
+): JoinStrings<FilterStrings<T>>;
 function cx(): string {
   let str = "",
     i = 0,


### PR DESCRIPTION
# Improved Type Inference for cx Function

This PR enhances the type system for the `cx` function to provide more accurate type literals in the return type without affecting runtime performance.

<img width="860" alt="image" src="https://github.com/user-attachments/assets/8209d67a-989a-4677-8286-85c7f85b8040">


## Changes
- Added `FilterStrings` type helper to process tuple types
- Added `JoinStrings` type helper to generate exact string literal types
- Updated function signature to preserve string literals

## Type System Improvements

### Before
```typescript
cx("foo", "bar")        // type: string
cx("foo", null, "bar")  // type: never
```

### After
```typescript
cx("foo", "bar")        // type: "foo bar"
cx("foo", null, "bar")  // type: "foo bar"
cx("a", "b", "c")       // type: "a b c"
// Conditional types are preserved
const test5 = cx("foo", false ? "bar" : "baz") satisfies "foo bar" | "foo baz";
```

## Implementation
The solution uses TypeScript's type system to:
1. Filter valid string arguments from the input tuple
2. Join the filtered strings with spaces
3. Preserve conditional types and unions

```typescript
type FilterStrings<T extends readonly any[]> = T extends readonly [infer F, ...infer R]
  ? F extends string
    ? [F, ...FilterStrings<R>]
    : FilterStrings<R>
  : [];

type JoinStrings<T extends readonly string[]> = T extends readonly [infer F, ...infer R]
  ? F extends string
    ? R extends readonly string[]
      ? R['length'] extends 0
        ? F
        : `${F} ${JoinStrings<R>}`
      : F
    : never
  : '';
```

## Justification
- Improves DX by providing exact type information
- Helps catch type errors at compile time
- No runtime performance impact (types are erased during compilation)
- Better IDE support with accurate autocompletion

## Notes
- This is a type-only change
- No runtime behavior modifications
- Fully backward compatible
- No bundle size impact

---

<h3>cx(...["foo", "bar"]) Considered but not included</h3>

While analyzing type improvements, we found an edge case with spread arrays:
```typescript
cx(...["foo", "bar"]) // Currently types as: `${string} ${string}`
```

when the array is statically known the workaround is to use the `as const` assertion:
```typescript
cx(...["foo", "bar"] as const) // types as: "foo bar"
```

Same situation for object properties:
```typescript
const obj = {  b: "bar" };
cx("foo, obj.b) // Currently types as: `${string} ${string}`
// fix
const obj = {  b: "bar" } as const;
cx("foo", obj.b) // types as: "foo bar"
```

We decided not to cover this case because:

1. **Type System Complexity**: Adding support for spread arrays would significantly increase type system complexity.

2. **Common Usage**: This pattern is rarely used in practice, as most calls to `cx` use direct string literals or variables.

Please let me know if you'd like me to explain any part of the implementation in more detail.
