### PR TITLE
fix: correct declaration module kind

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,14 @@
   "types": "./dist/classix.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/classix.d.ts",
-      "require": "./dist/cjs/classix.js",
-      "import": "./dist/esm/classix.mjs"
+      "import": {
+        "types": "./dist/classix.d.mts",
+        "default": "./dist/esm/classix.mjs"
+      },
+      "require": {
+        "types": "./dist/classix.d.ts",
+        "default": "./dist/cjs/classix.js"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -23,10 +23,16 @@ const config: RollupOptions[] = [
   {
     input: "src/index.ts",
     plugins: [dts()],
-    output: {
-      file: `dist/classix.d.ts`,
-      format: "es",
-    },
+    output: [
+      {
+        file: `dist/classix.d.ts`,
+        format: "es",
+      },
+      {
+        file: `dist/classix.d.mts`,
+        format: "es",
+      },
+    ],
   },
 ];
 


### PR DESCRIPTION
## Summary

- emit an ESM-specific declaration alongside the existing CommonJS declaration
- route `import` and `require` conditions to declarations with the matching module kind
- preserve the current runtime bundles and legacy package entry fields

## Root cause

The package has no `type: module`, so its shared `.d.ts` file is interpreted as CommonJS. ESM consumers resolve the `.mjs` runtime bundle but the CommonJS declaration, which produces the `Masquerading as CJS` diagnostic.

Closes #65.

## Validation

- `npx --yes @arethetypeswrong/cli --pack .` — no problems in Node10, Node16 CJS, Node16 ESM, or bundler resolution
- `npm run lint`
- `npm test` — 8 tests, 100% coverage
- `npm run build`
- `npm run size` — all six CJS/ESM limits pass
- `npx --no-install prettier --check package.json rollup.config.ts`
- `npm pack --dry-run --json`
- CommonJS and ESM conditional-export runtime probes
